### PR TITLE
Fix mail ID showing as a link in contacts.html

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -9,7 +9,7 @@
 <body>
   <h3>My Contacts</h3>
   <ul>
-    <li>Email : <a href="pandeyvibhas7@gmail.com">pandeyvibhas7@gmail.com</a></li>
+    <li>Email : pandeyvibhas7@gmail.com</li>
     <li>instagram:<a href="https://www.instagram.com/the_vibhas07/">the_vibhas07</a></li>
     <li>linkedin:<a href="https://www.linkedin.com/in/vibhas-pandey-480783226/">this</a></li>
   </ul>


### PR DESCRIPTION
In contacts.html, the mail ID was displaying as a link previously.
When clicked, a 404 page is displayed because no appropriate link has 
been set up. 
So, I changed the ID to be just normal text so as to not confuse the users